### PR TITLE
Restrict regex matching to URL beginning

### DIFF
--- a/polyaxon_nginx/schemas/ws.py
+++ b/polyaxon_nginx/schemas/ws.py
@@ -5,7 +5,7 @@ from polyaxon_nginx import settings
 from polyaxon_nginx.schemas.base import get_config
 
 OPTIONS = """
-location ~ /ws {{
+location /ws/ {{
     proxy_pass http://localhost:{port};
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;

--- a/tests/test_polyaxon.py
+++ b/tests/test_polyaxon.py
@@ -91,7 +91,7 @@ location /outputs/ {
 }
 
 
-location ~ /ws {
+location /ws/ {
     proxy_pass http://localhost:1337;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -335,7 +335,7 @@ location ~ /notebook/proxy/([-_.:\w]+)/(.*) {
     def test_ws_location_config(self):
         # settings.NGINX_PLUGINS = {'tensorboard': {'port': 6006}, 'notebook': {'port': 8888}}
         expected = """
-location ~ /ws {
+location /ws/ {
     proxy_pass http://localhost:1337;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -350,7 +350,7 @@ location ~ /ws {
 
         settings.WS_PORT = 8888
         expected = """
-location ~ /ws {
+location /ws/ {
     proxy_pass http://localhost:8888;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
This allows users like e.g. "wsimson" to query their projects via the API.

Previously the location rule intercepted `/app/wsimson` by matching the `/ws` in the middle of the URL.  This led to 404 response from the API.

This was a frustrating experience for all users named Walter Simson with the username wsimson.